### PR TITLE
Feat validate schema

### DIFF
--- a/create.js
+++ b/create.js
@@ -1,12 +1,18 @@
 import uuid from "uuid";
+import ajv from 'ajv';
 import * as dynamoDbLib from "./libs/dynamodb-lib";
 import { created, failure } from "./libs/response-lib";
+import schema from './schema.json'
 
 const TABLE_NAME = process.env.DATABASE_NAME
+const VALIDATE = new ajv().compile(schema)
 
 export async function main(event, context) {
   const data = JSON.parse(event.body);
-  console.log(data)
+  let valid = VALIDATE(data)
+  if (!valid) {
+    return failure({ status: false });
+  }
   const params = {
     TableName: TABLE_NAME,
     Item: {

--- a/mocks/create-event-grc.json
+++ b/mocks/create-event-grc.json
@@ -3,6 +3,7 @@
     "id": "grc:ποιητὴς"
   },
   "body": "{\"languageCode\":\"grc\",\"targetWord\":\"ποιητὴς\", \"important\":\"true\" }",
+  "body": "{\"ID\": \"grc-ποιητὴς\",\"listID\": \"auth0|999999999999999999999999-lat\",\"userID\": \"auth0|999999999999999999999999\", \"languageCode\": \"grc\",\"targetWord\": \"ποιητὴς\",\"important\": false,\"createdDT\": \"2019\/10\/03 @ 12:56:58\",\"context\": []}",
   "requestContext": {
     "authorizer": {
       "principalId": "mock-oauth2|9999999999"

--- a/mocks/create-event.json
+++ b/mocks/create-event.json
@@ -1,8 +1,8 @@
 {
   "pathParameters": {
-    "id": "lat:puella"
+    "id": "lat:footest"
   },
-  "body": "{\"languageCode\":\"lat\",\"targetWord\":\"puella\", \"important\":\"true\" }",
+  "body": "{\"ID\": \"lat-footest\",\"listID\": \"auth0|999999999999999999999999-lat\",\"userID\": \"auth0|999999999999999999999999\", \"languageCode\": \"lat\",\"targetWord\": \"footest\",\"important\": false,\"createdDT\": \"2019\/10\/03 @ 12:56:58\",\"context\": []}",
   "requestContext": {
     "authorizer": {
       "principalId": "mock-oauth2|9999999999"

--- a/mocks/delete-event.json
+++ b/mocks/delete-event.json
@@ -1,6 +1,6 @@
 {
   "pathParameters": {
-    "id": "lat:puella"
+    "id": "lat:footest"
   },
   "requestContext": {
     "authorizer": {

--- a/mocks/get-event.json
+++ b/mocks/get-event.json
@@ -1,6 +1,6 @@
 {
   "pathParameters": {
-    "id": "lat:puella"
+    "id": "lat:footest"
   },
   "requestContext": {
     "authorizer": {

--- a/mocks/item-complete.json
+++ b/mocks/item-complete.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-context.json
+++ b/mocks/item-empty-context.json
@@ -1,0 +1,14 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": []
+}

--- a/mocks/item-empty-exact.json
+++ b/mocks/item-empty-exact.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-lemmalist.json
+++ b/mocks/item-empty-lemmalist.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": ""
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-prefix.json
+++ b/mocks/item-empty-prefix.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-source.json
+++ b/mocks/item-empty-source.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-suffix.json
+++ b/mocks/item-empty-suffix.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-empty-word.json
+++ b/mocks/item-empty-word.json
@@ -1,0 +1,27 @@
+{
+  "ID": "lat-cespitum",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-invalid-id.json
+++ b/mocks/item-invalid-id.json
@@ -1,0 +1,27 @@
+{
+  "ID": "cespitum",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-invalid-language.json
+++ b/mocks/item-invalid-language.json
@@ -1,0 +1,27 @@
+{
+  "ID": "lat-cespitum",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "latin",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-invalid-list.json
+++ b/mocks/item-invalid-list.json
@@ -1,0 +1,27 @@
+{
+  "ID": "lat-cespitum",
+  "listID": "999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-invalid-user.json
+++ b/mocks/item-invalid-user.json
@@ -1,0 +1,30 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-no-homonym.json
+++ b/mocks/item-no-homonym.json
@@ -1,0 +1,27 @@
+{
+  "ID": "lat-cespitum",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-no-id.json
+++ b/mocks/item-no-id.json
@@ -1,0 +1,26 @@
+{
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-no-list.json
+++ b/mocks/item-no-list.json
@@ -1,0 +1,26 @@
+{
+  "ID": "lat-cespitum",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "targetWord": "cespitum",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "cespitum",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/item-no-user.json
+++ b/mocks/item-no-user.json
@@ -1,0 +1,29 @@
+{
+  "ID": "lat-pelles",
+  "listID": "auth0|999999999999999999999999-lat",
+  "languageCode": "lat",
+  "targetWord": "pelles",
+  "important": false,
+  "createdDT": "2019\/10\/03 @ 15:46:35",
+  "homonym": {
+    "targetWord": "pelles",
+    "lemmasList": "pello, pellis"
+  },
+  "context": [
+    {
+      "target": {
+        "source": "http:\/\/thelatinlibrary.com\/caesar\/gall4.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "pelles",
+          "prefix": "Atque in eam se consuetudinem adduxerunt ut locis frigidissimis neque vestitus praeter",
+          "suffix": "habeant quicquam, quarum propter exiguitatem magna est corporis pars aperta, et laventur in fluminibus.",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "targetWord": "pelles",
+      "createdDT": "2019\/10\/03 @ 15:46:35"
+    }
+  ]
+}

--- a/mocks/item-no-word.json
+++ b/mocks/item-no-word.json
@@ -1,0 +1,25 @@
+{
+  "ID": "lat-cespitum",
+  "listID": "auth0|999999999999999999999999-lat",
+  "userID": "auth0|999999999999999999999999",
+  "languageCode": "lat",
+  "important": false,
+  "createdDT": "2019/10/03 @ 12:56:58",
+  "context": [
+    {
+      "target": {
+        "source": "http://thelatinlibrary.com/apuleius/apuleius1.shtml",
+        "selector": {
+          "type": "TextQuoteSelector",
+          "exact": "cespitum",
+          "prefix": "] Thessaliam — nam et illic originis maternae nostrae fundamenta a Plutarcho illo inclito ac mox Sexto philosopho nepote eius prodita gloriam nobis faciunt — eam Thessaliam ex negotio petebam. Postquam ardua montium ac lubrica vallium et roscida",
+          "suffix": "et glebosa camporum <emenus> emersi, in equo indigena peralbo vehens iam eo quoque admodum fesso, ut ipse etiam fatigationem sedentariam incessus vegetatione discuterem in pedes desilio, equi sudorem <fronte detergeo>, frontem curiose exfrico, auris remulceo, frenos detraho, in gradum lenem sensim proveho, quoad lassitudinis incommodum alvi solitum ac naturale praesidium eliquaret. Ac dum is ientaculum ambulatorium prata quae praeterit ore in latus detorto pronus adfectat, duobus comitum qui forte paululum processerant tertium me facio. Ac dum ausculto quid sermonibus agitarent, alter exserto cachinno: \"Parce\" inquit \"in verba ista haec tam absurda tamque immania mentiendo.\" Isto accepto sititor alioquin novitatis: \"Immo vero\" inquam \"impertite sermonem non quidem curiosum sed qui velim scire vel cuncta vel certe plurima; simul iugi quod insurgimus aspritudinem fabularum lepida iucunditas levigabit.\"",
+          "languageCode": "lat"
+        }
+      },
+      "languageCode": "lat",
+      "createdDT": "2019/10/03 @ 12:56:58"
+    }
+  ]
+}
+

--- a/mocks/update-event.json
+++ b/mocks/update-event.json
@@ -1,7 +1,7 @@
 {
-  "body": "{\"languageCode\":\"lat\",\"targetWord\":\"puella\", \"important\":\"false\" }",
+  "body": "{\"ID\": \"lat-footest\",\"listID\": \"auth0|999999999999999999999999-lat\",\"userID\": \"auth0|999999999999999999999999\", \"languageCode\": \"lat\",\"targetWord\": \"footest\",\"important\": true,\"createdDT\": \"2019\/10\/03 @ 12:56:58\",\"context\": []}",
   "pathParameters": {
-    "id": "lat:puella"
+    "id": "lat:footest"
   },
   "requestContext": {
     "authorizer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -628,15 +628,15 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -1203,7 +1203,7 @@
       "dependencies": {
         "sax": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
           "dev": true
         }
@@ -1455,13 +1455,13 @@
       }
     },
     "babel-jest": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+      "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "^4.0.0",
-        "babel-preset-jest": "^21.2.0"
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-preset-jest": "^23.2.0"
       }
     },
     "babel-loader": {
@@ -1795,9 +1795,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-      "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+      "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
     "babel-plugin-source-map-support": {
@@ -2184,12 +2184,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-      "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+      "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^21.2.0",
+        "babel-plugin-jest-hoist": "^23.2.0",
         "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
@@ -3773,9 +3773,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -3997,7 +3997,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4018,12 +4019,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4038,17 +4041,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4165,7 +4171,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4177,6 +4184,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4191,6 +4199,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4198,12 +4207,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4222,6 +4233,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4302,7 +4314,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4314,6 +4327,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4399,7 +4413,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4435,6 +4450,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4454,6 +4470,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4497,12 +4514,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4741,6 +4760,32 @@
       "requires": {
         "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
       }
     },
     "has-ansi": {
@@ -5642,6 +5687,32 @@
         "yargs": "^9.0.0"
       },
       "dependencies": {
+        "babel-jest": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
+          "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-istanbul": "^4.0.0",
+            "babel-preset-jest": "^21.2.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
+          "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+          "dev": true
+        },
+        "babel-preset-jest": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
+          "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^21.2.0",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5792,9 +5863,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify": {
@@ -7984,8 +8055,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -8113,8 +8183,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8126,7 +8195,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8141,7 +8209,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -8253,8 +8320,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8387,7 +8453,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10466,7 +10531,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/AnomalyInnovations/serverless-nodejs-starter.git"
   },
   "devDependencies": {
-    "ajv": "^6.10.2",
     "aws-sdk": "^2.456.0",
     "babel-core": "^6.26.3",
     "babel-jest": "^23.4.0",
@@ -33,7 +32,8 @@
     "babel-runtime": "^6.26.0",
     "jsonwebtoken": "^8.5.1",
     "source-map-support": "^0.4.18",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "ajv": "^6.10.2"
   },
   "jest": {
     "verbose": true,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "url": "https://github.com/AnomalyInnovations/serverless-nodejs-starter.git"
   },
   "devDependencies": {
+    "ajv": "^6.10.2",
     "aws-sdk": "^2.456.0",
     "babel-core": "^6.26.3",
+    "babel-jest": "^23.4.0",
     "babel-loader": "^7.1.5",
     "babel-plugin-source-map-support": "^1.0.0",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -32,5 +34,22 @@
     "jsonwebtoken": "^8.5.1",
     "source-map-support": "^0.4.18",
     "uuid": "^3.3.2"
+  },
+  "jest": {
+    "verbose": true,
+    "testPathIgnorePatterns": [
+      "<rootDir>/node_modules/"
+    ],
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest",
+      "^.+\\.json$": "babel-jest"
+    },
+    "moduleNameMapper": {
+      "^@tests[/](.+)": "<rootDir>/tests/$1"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "json"
+    ]
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -8,17 +8,15 @@
       "$id": "#/definitions/targetWord",
       "type": "string",
       "title": "Target Word Schema",
-      "default": "",
       "examples": [
         "cespitum"
       ],
-      "pattern": "^(.*)$"
+      "pattern": "^(.+)$"
     },
     "languageCode": {
       "$id": "#/definitions/languageCode",
       "type": "string",
       "title": "Language Code Schema",
-      "default": "",
       "examples": [
         "lat"
       ],
@@ -28,7 +26,6 @@
       "$id": "#/definitions/createdDT",
       "type": "string",
       "title": "Created DT Schema",
-      "default": "",
       "examples": [
         "2019/10/03 @ 12:56:58"
       ],
@@ -60,11 +57,10 @@
           "$id": "#/definitions/imported/oa/exact",
           "type": "string",
           "title": "Exact Schema",
-          "default": "",
           "examples": [
             "cespitum"
           ],
-          "pattern": "^(.*)$"
+          "pattern": "^(.+)$"
         },
         "prefix": {
           "$id": "#/definitions/imported/oa/prefix",
@@ -110,31 +106,28 @@
       "$id": "#/properties/ID",
       "type": "string",
       "title": "Word Item ID Schema",
-      "default": "",
       "examples": [
         "lat-cespitum"
       ],
-      "pattern": "^\\w\\w\\w-(.*)$"
+      "pattern": "^\\w\\w\\w-(.+)$"
     },
     "listID": {
       "$id": "#/properties/listID",
       "type": "string",
       "title": "List ID Schema",
-      "default": "",
       "examples": [
         "auth0|5c76d34f0570702eabd4c27e-lat"
       ],
-      "pattern": "^(.*?)|(.*?)-\\w\\w\\w$"
+      "pattern": "^(.+?)\\|(.+?)-\\w\\w\\w$"
     },
     "userID": {
       "$id": "#/properties/userID",
       "type": "string",
       "title": "Userid Schema",
-      "default": "",
       "examples": [
-        "auth0|5c76d34f0570702eabd4c27e"
+        "auth0|999999999999"
       ],
-      "pattern": "^auth0|.*$"
+      "pattern": "^(.+?)\\|.+$"
     },
     "languageCode": {
       "$ref": "#/definitions/languageCode"
@@ -210,7 +203,7 @@
                 "examples": [
                   "http://thelatinlibrary.com/apuleius/apuleius1.shtml"
                 ],
-                "pattern": "^(.*)$"
+                "pattern": "^(.+)$"
               },
               "selector": {
                 "$ref": "#/definitions/imported/oa/selector"

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alpheios.net/schemas/apis/user-word/item.json",
+  "type": "object",
+  "title": "Schema for a User Word Item",
+  "definitions": {
+    "targetWord": {
+      "$id": "#/definitions/targetWord",
+      "type": "string",
+      "title": "Target Word Schema",
+      "default": "",
+      "examples": [
+        "cespitum"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "languageCode": {
+      "$id": "#/definitions/languageCode",
+      "type": "string",
+      "title": "Language Code Schema",
+      "default": "",
+      "examples": [
+        "lat"
+      ],
+      "pattern": "^\\w\\w\\w$"
+    },
+    "createdDT": {
+      "$id": "#/definitions/createdDT",
+      "type": "string",
+      "title": "Created DT Schema",
+      "default": "",
+      "examples": [
+        "2019/10/03 @ 12:56:58"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "selector": {
+      "$id": "#/definitions/imported/oa/selector",
+      "type": "object",
+      "title": "Selector Schema (see http://www.w3.org/ns/oa#TextQuoteSelector )",
+      "required": [
+        "type",
+        "exact",
+        "prefix",
+        "suffix",
+        "languageCode"
+      ],
+      "properties": {
+        "type": {
+          "$id": "#/definitions/imported/oa/type",
+          "type": "string",
+          "title": "Type Schema",
+          "default": "TextQuoteSelector",
+          "examples": [
+            "TextQuoteSelector"
+          ],
+          "pattern": "^TextQuoteSelector$"
+        },
+        "exact": {
+          "$id": "#/definitions/imported/oa/exact",
+          "type": "string",
+          "title": "Exact Schema",
+          "default": "",
+          "examples": [
+            "cespitum"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "prefix": {
+          "$id": "#/definitions/imported/oa/prefix",
+          "type": "string",
+          "title": "Prefix Schema",
+          "default": "",
+          "examples": [
+            "words that come before"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "suffix": {
+          "$id": "#/definitions/imported/oa/suffix",
+          "type": "string",
+          "title": "Suffix Schema",
+          "default": "",
+          "examples": [
+            "words that come after"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "languageCode": {
+          "$ref": "#/definitions/languageCode"
+        }
+      }
+    }
+  },
+  "required": [
+    "ID",
+    "listID",
+    "userID",
+    "languageCode",
+    "targetWord",
+    "important",
+    "createdDT",
+    "context"
+  ],
+  "optional": [
+    "homonym"
+  ],
+  "properties": {
+    "ID": {
+      "$id": "#/properties/ID",
+      "type": "string",
+      "title": "Word Item ID Schema",
+      "default": "",
+      "examples": [
+        "lat-cespitum"
+      ],
+      "pattern": "^\\w\\w\\w-(.*)$"
+    },
+    "listID": {
+      "$id": "#/properties/listID",
+      "type": "string",
+      "title": "List ID Schema",
+      "default": "",
+      "examples": [
+        "auth0|5c76d34f0570702eabd4c27e-lat"
+      ],
+      "pattern": "^(.*?)|(.*?)-\\w\\w\\w$"
+    },
+    "userID": {
+      "$id": "#/properties/userID",
+      "type": "string",
+      "title": "Userid Schema",
+      "default": "",
+      "examples": [
+        "auth0|5c76d34f0570702eabd4c27e"
+      ],
+      "pattern": "^auth0|.*$"
+    },
+    "languageCode": {
+      "$ref": "#/definitions/languageCode"
+    },
+    "targetWord": {
+      "$ref": "#/definitions/targetWord"
+    },
+    "important": {
+      "$id": "#/properties/important",
+      "type": "boolean",
+      "title": "Important Schema",
+      "default": false,
+      "examples": [
+        false
+      ]
+    },
+    "createdDT": {
+      "$ref": "#/definitions/createdDT"
+    },
+    "homonym": {
+      "$id": "#/properties/homonym",
+      "type": "object",
+      "title": "Homonym Schema",
+      "required": [
+        "targetWord",
+        "lemmasList"
+      ],
+      "properties": {
+        "targetWord": {
+          "$ref": "#/definitions/targetWord"
+        },
+        "lemmasList": {
+          "$id": "#/properties/homonym/properties/lemmasList",
+          "type": "string",
+          "title": "Lemmas List Schema",
+          "default": "",
+          "examples": [
+            "cespes"
+          ],
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "context": {
+      "$id": "#/properties/context",
+      "type": "array",
+      "title": "Context Schema",
+      "items": {
+        "$id": "#/properties/context/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "target",
+          "languageCode",
+          "targetWord",
+          "createdDT"
+        ],
+        "properties": {
+          "target": {
+            "$id": "#/properties/context/items/properties/target",
+            "type": "object",
+            "title": "Context Target Schema",
+            "required": [
+              "source",
+              "selector"
+            ],
+            "properties": {
+              "source": {
+                "$id": "#/properties/context/items/properties/target/properties/source",
+                "type": "string",
+                "title": " Source Schema",
+                "default": "",
+                "examples": [
+                  "http://thelatinlibrary.com/apuleius/apuleius1.shtml"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "selector": {
+                "$ref": "#/definitions/imported/oa/selector"
+              }
+            }
+          },
+          "languageCode": {
+            "$ref": "#/definitions/languageCode"
+          },
+          "targetWord": {
+            "$ref": "#/definitions/targetWord"
+          },
+          "createdDT": {
+            "$ref": "#/definitions/createdDT"
+          }
+        }
+      }
+    }
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ provider:
     AUTH0_AUDIENCE: alpheios.net:apis
     AUTH0_TEST_ID: ${file(./test_id)}
     DATABASE_NAME: user-word-items
+    SCHEMA: ${file(./schema.json)}
 
   # 'iamRoleStatements' defines the permission policy for the Lambda function.
   # In this case Lambda functions are granted with permissions to access DynamoDB.

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,7 +23,6 @@ provider:
     AUTH0_AUDIENCE: alpheios.net:apis
     AUTH0_TEST_ID: ${file(./test_id)}
     DATABASE_NAME: user-word-items
-    SCHEMA: ${file(./schema.json)}
 
   # 'iamRoleStatements' defines the permission policy for the Lambda function.
   # In this case Lambda functions are granted with permissions to access DynamoDB.

--- a/tests/ajv.test.js
+++ b/tests/ajv.test.js
@@ -7,6 +7,18 @@ import noHomonym from '../mocks/item-no-homonym.json'
 import withHomonym from '../mocks/item-complete.json'
 import noUser from '../mocks/item-no-user.json'
 import invalidUser from '../mocks/item-invalid-user.json'
+import invalidList from '../mocks/item-invalid-list.json'
+import noList from '../mocks/item-no-list.json'
+import invalidId from '../mocks/item-invalid-id.json'
+import noId from '../mocks/item-no-id.json'
+import invalidLanguage from '../mocks/item-invalid-language.json'
+import noWord from '../mocks/item-no-word.json'
+import emptyWord from '../mocks/item-empty-word.json'
+import emptyLemmasList from '../mocks/item-empty-lemmalist.json'
+import emptyContext from '../mocks/item-empty-context.json'
+import emptyExact from '../mocks/item-empty-exact.json'
+import emptyPrefix from '../mocks/item-empty-prefix.json'
+import emptySuffix from '../mocks/item-empty-suffix.json'
 
 describe('ajv.test.js', () => {
 
@@ -28,6 +40,71 @@ describe('ajv.test.js', () => {
 
   it('fails with invalid user', () => {
     let valid = validate(invalidUser)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with no user', () => {
+    let valid = validate(noUser)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with invalid list', () => {
+    let valid = validate(invalidList)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with no list', () => {
+    let valid = validate(noList)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with invalid id', () => {
+    let valid = validate(invalidId)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with no id', () => {
+    let valid = validate(noId)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with invalid language', () => {
+    let valid = validate(invalidLanguage)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with no word', () => {
+    let valid = validate(noWord)
+    expect(valid).toBeFalsy()
+  })
+
+  it('fails with empty word', () => {
+    let valid = validate(emptyWord)
+    expect(valid).toBeFalsy()
+  })
+
+  it('allows empty lemmas list', () => {
+    let valid = validate(emptyLemmasList)
+    expect(valid).toBeTruthy()
+  })
+
+  it('allows empty context', () => {
+    let valid = validate(emptyContext)
+    expect(valid).toBeTruthy()
+  })
+
+  it('allows empty prefix', () => {
+    let valid = validate(emptyPrefix)
+    expect(valid).toBeTruthy()
+  })
+
+  it('allows empty suffix', () => {
+    let valid = validate(emptySuffix)
+    expect(valid).toBeTruthy()
+  })
+
+  it('fails empty exact', () => {
+    let valid = validate(emptyExact)
     expect(valid).toBeFalsy()
   })
 })

--- a/tests/ajv.test.js
+++ b/tests/ajv.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+/* eslint-disable no-unused-vars */
+
+import ajv from 'ajv'
+import schema from '../schema.json'
+import noHomonym from '../mocks/item-no-homonym.json'
+import withHomonym from '../mocks/item-complete.json'
+import noUser from '../mocks/item-no-user.json'
+import invalidUser from '../mocks/item-invalid-user.json'
+
+describe('ajv.test.js', () => {
+
+  let validate
+
+  beforeAll(() => {
+    let validator = new ajv()
+    validate = validator.compile(schema)
+  })
+  it('validates without homonym', () => {
+    let valid = validate(noHomonym)
+    expect(valid).toBeTruthy()
+  })
+
+  it('validates with homonym', () => {
+    let valid = validate(withHomonym)
+    expect(valid).toBeTruthy()
+  })
+
+  it('fails with invalid user', () => {
+    let valid = validate(invalidUser)
+    expect(valid).toBeFalsy()
+  })
+})

--- a/tests/handler.test.js
+++ b/tests/handler.test.js
@@ -1,6 +1,6 @@
-import * as handler from '../handler';
+//import * as handler from '../handler';
 
-test('hello', async () => {
+test.skip('hello', async () => {
   const event = 'event';
   const context = 'context';
   const callback = (error, response) => {

--- a/tests/jwt.test.js
+++ b/tests/jwt.test.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+/* eslint-disable no-unused-vars */
+
+import jwt from 'jsonwebtoken'
+
+describe('jwt.test.js', () => {
+
+  it('validates unexpired token', () => {
+    //expect.assertions(0)
+    let token = jwt.sign({
+      exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      data: 'foobar'
+    }, 'secret');
+    try {
+      jwt.verify(token,'secret',(err,decoded) => {
+        console.log(decoded)
+        expect(err).not.toBeDefined()
+      })
+    } catch (err) {
+    }
+  })
+  it('fails expired token', () => {
+    //expect.assertions(1)
+    let token = jwt.sign({
+      exp: Math.floor(Date.now() / 1000) - (60 * 60),
+      data: 'foobar'
+    }, 'secret');
+    try {
+      jwt.verify(token,'secret',(err,decoded) => {
+        expect(err).toBeDefined()
+        console.log(err)
+      })
+    } catch (err) {
+        console.log(err)
+        expect(err).toBeDefined()
+    }
+  })
+})

--- a/update.js
+++ b/update.js
@@ -1,10 +1,17 @@
 import * as dynamoDbLib from "./libs/dynamodb-lib";
+import ajv from 'ajv';
 import { success, failure } from "./libs/response-lib";
+import schema from './schema.json'
 
 const TABLE_NAME = process.env.DATABASE_NAME
+const VALIDATE = new ajv().compile(schema)
 
 export async function main(event, context) {
   const data = JSON.parse(event.body);
+  let valid = VALIDATE(data)
+  if (!valid) {
+    return failure({ status: false });
+  }
   const params = {
     TableName: TABLE_NAME,
     // 'Key' defines the partition key and sort key of the item to be updated


### PR DESCRIPTION
This is a first stab at adding data validation to the user word api.

I am using a JSON Schema to describe the expected schema of the object.  Ideally, this should be part of the data model object, but our implementation has the remove and local db adapters creating their own custom serialization of the object, according to the storage requirements. I thought about putting the schema in the remote db adapter (in the wordlist repo), but decided for now to keep it with with the API.  Eventually I would like to have a formal documentation of these apis, and the schema is a first step toward that. It's all imperfect ...

Anyway, i'd like get your thoughts on this approach and whether you have any big concerns.

Most of the files in the commit are just mocks for testing. The important files to look at are:

- update.js  (the UPDATE handler)
- create.js (the CREATE handler)
- schema.json (the JSON schema for the word item object, as is expected by this API)